### PR TITLE
Fix ISR mask

### DIFF
--- a/Chime/VM.m
+++ b/Chime/VM.m
@@ -44,7 +44,7 @@
       uint32_t opcodes =
           from64To32([[_registers objectForKey:@"ISR"] integerValue]);
       // This is a mask to remove the ending 2 bits of any number
-      opcodes &= -8;
+      opcodes &= -4;
       opcode = @(opcodes >> 27);
       opcodes = opcodes << 5;
       [_registers setObject:@(opcodes) forKey:@"ISR"];

--- a/Chime/VM.m
+++ b/Chime/VM.m
@@ -44,7 +44,7 @@
       uint32_t opcodes =
           from64To32([[_registers objectForKey:@"ISR"] integerValue]);
       // This is a mask to remove the ending 2 bits of any number
-      opcodes &= -4;
+      opcodes &= -(1 << 2);
       opcode = @(opcodes >> 27);
       opcodes = opcodes << 5;
       [_registers setObject:@(opcodes) forKey:@"ISR"];


### PR DESCRIPTION
The correct bit pattern to mask off the bottom two bits is `100`, with the `1` being the bit used to extend the pattern to the left. That bit pattern, interpreted as an integer and written in decimal, is `-4`. Except, we write `-4` in the more evocative manner: `-(1 << 2)`, which makes it more clear that our intention is to mask two bits off.